### PR TITLE
If target is not passed set it as same as source directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ Usage:
     Print debug output
 ```
 
-- This utility requires `-s` and `-t` to be passed.
+- This utility requires `-s` to be passed.
 - `-s` is source directory from which files will be read.
-- `-t` is target directory where generated template will be stored.
+- `-t` is target directory where generated template will be stored. If not passed
+  value will be same as `-s`
 - `template-generator` will read config file specified in `-c` flag or
   if not defined it will read config from `source_directory/template-files.json`
 - The config file will be stored in root of all branches named `template-files.json`.
@@ -81,4 +82,3 @@ Usage:
   of `___projectName___` with `{{ .projectName }}` and store generated file in `template`.
 - The `init` project will read `template` and generate actual files at location
   of `real` depending on user input.
-

--- a/internal/parsers/args.go
+++ b/internal/parsers/args.go
@@ -73,10 +73,6 @@ func ParseArgs() (*Config, error) {
 		return nil, fmt.Errorf("The parameter `s|source` is required")
 	}
 
-	if targetDirectory == "" {
-		return nil, fmt.Errorf("The parameter `t|target` is required")
-	}
-
 	config := Config{}
 
 	sourceDirectory, err = getAbsPath(sourceDirectory)
@@ -89,9 +85,13 @@ func ParseArgs() (*Config, error) {
 		return nil, err
 	}
 
-	targetDirectory, err = filepath.Abs(targetDirectory)
-	if err != nil {
-		return nil, err
+	if targetDirectory == "" {
+		targetDirectory = sourceDirectory
+	} else {
+		targetDirectory, err = filepath.Abs(targetDirectory)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	config.Verbose = verbose

--- a/internal/parsers/args_test.go
+++ b/internal/parsers/args_test.go
@@ -53,12 +53,16 @@ func TestParse(t *testing.T) {
 			expected_error: fmt.Errorf("The parameter `s|source` is required"),
 		},
 		{
-			name: "returns error if target not included",
+			name: "returns source if target not included",
 			init: func() {
-				parsers.FSet.Set("s", "test")
+				parsers.FSet.Set("s", "../../tests/data/")
 			},
-			expected_value: nil,
-			expected_error: fmt.Errorf("The parameter `t|target` is required"),
+			expected_value: &parsers.Config{
+				ConfigFile:      configFilePath,
+				SourceDirectory: sourceDirectoryPath,
+				TargetDirectory: sourceDirectoryPath,
+			},
+			expected_error: nil,
 		},
 		{
 			name: "returns valid config",


### PR DESCRIPTION
The templates are stored in `source/templates/` directory.
So it will be way easier to not specify target directory via cli.
This PR updates generator to assign target directory same as source directory if not passed via cli args.